### PR TITLE
Found a bug & added a feature

### DIFF
--- a/index.js
+++ b/index.js
@@ -160,11 +160,17 @@ module.exports = function(command, opt) {
 		// after options and switches are added, then add either testClass or testSuite
 
 		// Priority:
+        // - config file path from gulp.src()
 		// - configuration file
 		// - testSuite
 		// - testClass
 
 		var skip;
+
+        if ((file.path) && (! skip) && (!opt.noConfiguration)){
+            cmd += ' -c ' + file.path;
+            skip = true;
+        }
 
 		if ((opt.configurationFile) && (! skip) && (!opt.noConfiguration)){
 			cmd += ' -c ' + opt.configurationFile;
@@ -216,7 +222,10 @@ module.exports = function(command, opt) {
 					cb(null, file);
 				}
 
-			});
+			}).stdout.on('data', function(data) {
+                var str = data.toString();
+                process.stdout.write(str);
+            });
 		}
 
 	});


### PR DESCRIPTION
I was trying to follow the examples and unless I was doing something wrong, I could not get to work. It kept erroring out, displaying the phpunit --help text.

```
gulp.task('test', function() {
    gulp.src('./configs/phpunit.xml').pipe(phpunit());
});
```
I started digging around a little, and found the issue, that file.path was never being read. I added that in as a priority over the config options. 

I also really like the streaming output of the progress, instead of waiting at a blank screen, so I added that also.

Thanks for creating this plugin! It's much cleaner than what I was trying to do.