### PR TITLE
Fixed reporting as finished before actually finished

### DIFF
--- a/index.js
+++ b/index.js
@@ -231,14 +231,6 @@ module.exports = function(command, opt, callback) {
 					msg.error(stderr);
 				}
 
-				// if (!opt.silent) {
-				//            // Trim trailing cr-lf
-				//            stdout = stdout.trim();
-				//            if (stdout) {
-				//                           // console.log(stdout);
-				//            }
-				// }
-
 				// call user callback if error occurs
 				if (error) {
 					if ( opt.statusLine ) {
@@ -279,7 +271,7 @@ module.exports = function(command, opt, callback) {
 
 			}).stdout.on('data', function(data) {
 				var str = data.toString();
-				cb(null, str);
+				process.stdout.write(str);
 			});
 		}
 

--- a/index.js
+++ b/index.js
@@ -270,8 +270,10 @@ module.exports = function(command, opt, callback) {
 				}
 
 			}).stdout.on('data', function(data) {
-				var str = data.toString();
-				process.stdout.write(str);
+				if (!opt.silent) {
+					var str = data.toString();
+					process.stdout.write(str);
+				}
 			});
 		}
 


### PR DESCRIPTION
Fixing an issue were gulp-phpunit is calling the end callback on every stdout for the async output instead of just calling it once at the end of the process. This was causing gulp to assume the task had passed successfully before the task had even completed, even if the tests are failing!