### PR TITLE
Bumps node-notifier dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "gulp-util": "3.0.8",
     "lodash": "^4.15.0",
     "map-stream": "~0.0.4",
-    "node-notifier": "4.6.1",
+    "node-notifier": "5.0.1",
     "shelljs": "0.7.6"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates the dependency of `node-notifier` to the latest [newly released `v5.0.1`](https://github.com/mikaelbr/node-notifier/blob/master/CHANGELOG.md#v500).

With this change there are a lot fewer dependencies as the built in CLI is removed, and other dependencies are trimmed. 

Doesn't look like there is any change in the way it's used in this package.